### PR TITLE
fix: clippy lints and deprecation warnings in the examples

### DIFF
--- a/common/examples/lowlevel_1.rs
+++ b/common/examples/lowlevel_1.rs
@@ -17,6 +17,7 @@ struct GetInfoResponse {
 struct GetInfoRequest {}
 
 fn main() {
+    #[allow(deprecated)]
     let sock = env::home_dir().unwrap().join(".lightning/lightning-rpc");
     println!("Using socket {}", sock.display());
     let client = client::Client::new(&sock);

--- a/common/examples/lowlevel_2.rs
+++ b/common/examples/lowlevel_2.rs
@@ -7,6 +7,7 @@ use std::env;
 use clightningrpc_common::{client, types};
 
 fn main() {
+    #[allow(deprecated)]
     let sock = env::home_dir().unwrap().join(".lightning/lightning-rpc");
     println!("Using socket {}", sock.display());
     let client = client::Client::new(&sock);

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -77,6 +77,7 @@ impl error::Error for Error {
     }
 }
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 /// A JSONRPCv2.0 spec compilant error object
 pub struct RpcError {

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{Error, RpcError};
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// A standard JSONRPC request object
 pub struct Request<'f, T: Serialize> {
@@ -20,6 +21,7 @@ pub struct Request<'f, T: Serialize> {
     pub jsonrpc: &'f str,
 }
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 /// A standard JSONRPC response object
 pub struct Response<T> {

--- a/plugin/src/commands/mod.rs
+++ b/plugin/src/commands/mod.rs
@@ -39,7 +39,7 @@ pub trait RPCCommandClone<T: Clone> {
     fn clone_box(&self) -> Box<dyn RPCCommand<T>>;
 }
 
-impl<'a, F, T: Clone> RPCCommandClone<T> for F
+impl<F, T: Clone> RPCCommandClone<T> for F
 where
     F: 'static + RPCCommand<T> + Clone,
 {

--- a/plugin/src/errors.rs
+++ b/plugin/src/errors.rs
@@ -18,11 +18,11 @@ impl PluginError {
     where
         Self: Sized,
     {
-        return PluginError {
+        PluginError {
             code,
             msg: msg.to_string(),
-            data: data.to_owned(),
-        };
+            data,
+        }
     }
 }
 

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -52,7 +52,7 @@ where
 
 impl<'a, T: 'a + Clone> Plugin<T> {
     pub fn new(state: T, dynamic: bool) -> Self {
-        return Plugin {
+        Plugin {
             state,
             option: HashSet::new(),
             rpc_method: HashMap::new(),
@@ -63,7 +63,7 @@ impl<'a, T: 'a + Clone> Plugin<T> {
             dynamic,
             conf: None,
             on_init: None,
-        };
+        }
     }
 
     pub fn on_init(&'a mut self, callback: &'static OnInit<T>) -> Self {

--- a/plugin_macros/src/lib.rs
+++ b/plugin_macros/src/lib.rs
@@ -92,8 +92,7 @@ pub fn rpc_method(attr: TokenStream, item: TokenStream) -> TokenStream {
         _ => panic!("The macros is applied over a not function declaration"),
     };
     let rpc_call = generate_method_call(&macro_args, fn_dec);
-    let res = generate_rpc_method(&item, &rpc_call).parse().unwrap();
-    res
+    generate_rpc_method(&item, &rpc_call).parse().unwrap()
 }
 
 // helper method to generator the RPCCall struct and make the code more readable and cleaner.
@@ -154,11 +153,10 @@ fn generate_rpc_method(item: &TokenStream, method_call: &RPCCall) -> String {
         method_call.description,
         method_call.description,
         method_call.usage,
-        item.to_string(),
+        item,
         method_call.struct_name,
-        method_call.to_string(),
+        method_call,
     )
-    .to_owned()
 }
 
 /// procedural macros to generate the code to register a RPC method created with the
@@ -210,7 +208,7 @@ pub fn add_plugin_rpc(items: TokenStream) -> TokenStream {
         input[0],
         input[2]
             .to_string()
-            .replace("\"", "")
+            .replace('"', "")
             .as_str()
             .to_case(Case::Pascal)
     )
@@ -317,11 +315,10 @@ fn generate_notification_method(item: &TokenStream, method_call: &RPCNotificatio
         method_call.struct_name,
         method_call.struct_name,
         method_call.original_name,
-        item.to_string(),
+        item,
         method_call.struct_name,
-        method_call.to_string(),
+        method_call,
     )
-    .to_owned()
 }
 
 /// procedural macros to generate the code to register a RPC method created with the
@@ -370,7 +367,7 @@ pub fn plugin_register_notification(items: TokenStream) -> TokenStream {
         input[0],
         input[2]
             .to_string()
-            .replace("\"", "")
+            .replace('"', "")
             .as_str()
             .to_case(Case::Pascal)
     )

--- a/rpc/examples/ex_1.rs
+++ b/rpc/examples/ex_1.rs
@@ -5,6 +5,7 @@ use std::env;
 use clightningrpc::LightningRPC;
 
 fn main() {
+    #[allow(deprecated)]
     let sock = env::home_dir().unwrap().join(".lightning/lightning-rpc");
     println!("Using socket {}", sock.display());
 

--- a/rpc/src/lightningrpc.rs
+++ b/rpc/src/lightningrpc.rs
@@ -74,7 +74,7 @@ impl LightningRPC {
     /// Return feerate estimates, either satoshi-per-kw ({style} perkw) or satoshi-per-kb ({style}
     /// perkb).
     pub fn feerates(&self, style: &str) -> Result<responses::FeeRates, Error> {
-        self.call("feerates", requests::FeeRates { style: style })
+        self.call("feerates", requests::FeeRates { style })
     }
 
     /// Show node {id} (or all, if no {id}), in our local network view.
@@ -225,7 +225,7 @@ impl LightningRPC {
         self.call(
             "pay",
             requests::Pay {
-                bolt11: bolt11,
+                bolt11,
                 msatoshi: options.msatoshi,
                 description: options.description,
                 riskfactor: options.riskfactor,
@@ -305,6 +305,7 @@ impl LightningRPC {
     /// specified search from {fromid} otherwise use this node as source. Randomize the route with
     /// up to {fuzzpercent} (0.0 -> 100.0, default 5.0) using {seed} as an arbitrary-size string
     /// seed.
+    #[allow(clippy::too_many_arguments)]
     pub fn getroute(
         &self,
         id: &str,


### PR DESCRIPTION
The title explains everything.

I am planning on making some more PRs in the near future and wanted to get these upstreamed so that I don't have to search through clippy output every time.