### PR TITLE
fix(conf): allow to specify create_if_missing

### DIFF
--- a/conf/CHANGELOG.md
+++ b/conf/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.0.1-alpha.4
+
+## Fixed
+- allow to specify `create_if_missing` ([commit](https://github.com/laanwj/cln4rust/commit/fe905fcc5d67a2da2a41d8f668095ed6533fa011)). @vincenzopalazzo 24-02-2023
+
+
 # v0.0.1-alpha.3
 
 ## Added

--- a/conf/Cargo.toml
+++ b/conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clightningrpc-conf"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 edition = "2021"
 authors = ["Vincenzo Palazzo <vincenzopalazzodev@gmail.com>"]
 license = "CC0-1.0"

--- a/conf/changelog.json
+++ b/conf/changelog.json
@@ -1,10 +1,10 @@
 {
   "package_name": "conf",
-  "version": "v0.0.1-alpha.3",
+  "version": "v0.0.1-alpha.4",
   "api": {
     "name": "github",
     "repository": "laanwj/rust-clightning-rpc",
-    "branch": "macros/multymap"
+    "branch": "macros/conf-create"
   },
   "generation_method": {
     "name": "semver-v2",

--- a/conf/src/file.rs
+++ b/conf/src/file.rs
@@ -1,6 +1,7 @@
 //! file implementation to read and write content
 use std::fs;
 use std::io::{Error, Write};
+use std::path::Path;
 
 pub trait SyncFile {
     /// sync version to write into the file
@@ -17,6 +18,10 @@ pub trait SyncFile {
     }
 
     fn path(&self) -> String;
+
+    fn exist(&self) -> bool {
+        Path::exists(Path::new(&self.path()))
+    }
 }
 
 pub struct File {


### PR DESCRIPTION
Fixes the library panic when trying to read from
a file that do not exist.