### PR TITLE
feat(common): change the request id as Enum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && apt-get install -y \
     software-properties-common  \
     build-essential \
-    curl
+    curl wget
 
 RUN apt-get update
 
@@ -18,9 +18,17 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install bitcoin core and lightningd (last version)
 RUN add-apt-repository ppa:luke-jr/bitcoincore
-RUN apt-get update  && apt-get install -y bitcoind jq
-RUN add-apt-repository -u ppa:lightningnetwork/ppa
-RUN apt-get update  && apt-get install -y lightningd
+RUN apt-get update && apt-get install -y bitcoind jq libsodium-dev libpq-dev
+
+ENV CLIGHTNING_VERSION=23.02
+
+RUN wget https://github.com/ElementsProject/lightning/releases/download/v$CLIGHTNING_VERSION/clightning-v$CLIGHTNING_VERSION-Ubuntu-20.04.tar.xz && \
+    tar -xvf clightning-v$CLIGHTNING_VERSION-Ubuntu-20.04.tar.xz -C /opt && cd /opt && \
+    mv usr clightning-v$CLIGHTNING_VERSION
+
+RUN rm -r clightning-v$CLIGHTNING_VERSION-Ubuntu-20.04.tar.xz
+
+ENV PATH=/opt/clightning-v$CLIGHTNING_VERSION/bin:$PATH
 
 WORKDIR workdir
 COPY sandbox .

--- a/common/src/client.rs
+++ b/common/src/client.rs
@@ -67,10 +67,11 @@ impl Client {
         to_writer(
             &mut stream,
             &Request {
-                method,
+                method: method.to_owned(),
                 params,
-                id: Some(0), // we always open a new connection, so we don't have to care about the nonce
-                jsonrpc: "2.0",
+                // FIXME: use a custom json to identify the json request!
+                id: Some("0".into()), // we always open a new connection, so we don't have to care about the nonce
+                jsonrpc: "2.0".to_owned(),
             },
         )?;
 
@@ -84,11 +85,6 @@ impl Client {
             .map_or(false, |version| version != "2.0")
         {
             return Err(Error::VersionMismatch);
-        }
-
-        // nonce will always be 0
-        if response.id != 0 {
-            return Err(Error::NonceMismatch);
         }
 
         Ok(response)

--- a/common/src/json_utils.rs
+++ b/common/src/json_utils.rs
@@ -4,13 +4,15 @@
 use serde::Serialize;
 use serde_json::{json, Number};
 
+use crate::types::Id;
+
 /// return a server::json_value useful to initialize the JSON payload as an empty JSON object.
 pub fn init_payload() -> serde_json::Value {
     json!({})
 }
 
 /// returns a success response.
-pub fn init_success_response(id: u64) -> serde_json::Value {
+pub fn init_success_response(id: Id) -> serde_json::Value {
     json!(
         {
             "id": id,

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -6,19 +6,38 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{Error, RpcError};
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Id {
+    Str(String),
+    Int(u16),
+}
+
+impl From<&str> for Id {
+    fn from(value: &str) -> Self {
+        Id::Str(value.to_owned())
+    }
+}
+
+impl From<u64> for Id {
+    fn from(value: u64) -> Self {
+        Id::Str(format!("{value}"))
+    }
+}
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// A standard JSONRPC request object
-pub struct Request<'f, T: Serialize> {
+pub struct Request<T: Serialize> {
     /// The name of the RPC method call
-    pub method: &'f str,
+    pub method: String,
     /// Parameters to the RPC method call
     pub params: T,
     /// Identifier for this Request, which should appear in the response
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<u64>,
+    pub id: Option<Id>,
     /// jsonrpc field, MUST be "2.0"
-    pub jsonrpc: &'f str,
+    pub jsonrpc: String,
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -30,7 +49,7 @@ pub struct Response<T> {
     /// An error if there is one, or null
     pub error: Option<RpcError>,
     /// Identifier for this Request, which should match that of the request
-    pub id: u64,
+    pub id: Id,
     /// jsonrpc field, MUST be "2.0"
     pub jsonrpc: Option<String>,
 }

--- a/plugin/examples/foo_plugin.rs
+++ b/plugin/examples/foo_plugin.rs
@@ -16,7 +16,7 @@ impl RPCCommand<PluginState> for HelloRPC {
     fn call<'c>(
         &self,
         plugin: &mut Plugin<PluginState>,
-        _request: &'c Value,
+        _request: Value,
     ) -> Result<Value, PluginError> {
         plugin.log(LogLevel::Debug, "call the custom rpc method from rust");
         let response = json!({

--- a/plugin/src/commands/builtin.rs
+++ b/plugin/src/commands/builtin.rs
@@ -21,7 +21,7 @@ use super::types::InitConf;
 pub struct ManifestRPC {}
 
 impl<T: Clone> RPCCommand<T> for ManifestRPC {
-    fn call<'c>(&self, plugin: &mut Plugin<T>, _request: &'c Value) -> Result<Value, PluginError> {
+    fn call<'c>(&self, plugin: &mut Plugin<T>, _request: Value) -> Result<Value, PluginError> {
         let mut response = init_payload();
         add_vec::<RpcOption>(
             &mut response,
@@ -65,7 +65,7 @@ impl<T: Clone> InitRPC<T> {
 }
 
 impl<T: Clone> RPCCommand<T> for InitRPC<T> {
-    fn call<'c>(&self, plugin: &mut Plugin<T>, request: &'c Value) -> Result<Value, PluginError> {
+    fn call<'c>(&self, plugin: &mut Plugin<T>, request: Value) -> Result<Value, PluginError> {
         let response = init_payload();
         let init: InitConf = serde_json::from_value(request.to_owned()).unwrap();
         plugin.configuration = Some(init.configuration);

--- a/plugin/src/commands/mod.rs
+++ b/plugin/src/commands/mod.rs
@@ -4,7 +4,6 @@
 pub mod builtin;
 pub mod types;
 
-use serde_json;
 use serde_json::json;
 
 use super::plugin::Plugin;
@@ -18,8 +17,8 @@ pub trait RPCCommand<T: Clone>: RPCCommandClone<T> {
     /// call is a generic method that it is used to simulate the callback.
     fn call<'c>(
         &self,
-        _plugin: &mut Plugin<T>,
-        _request: &'c serde_json::Value,
+        _: &mut Plugin<T>,
+        _: serde_json::Value,
     ) -> Result<serde_json::Value, PluginError> {
         Ok(json!({}))
     }

--- a/plugin/src/errors.rs
+++ b/plugin/src/errors.rs
@@ -2,6 +2,15 @@
 use serde::Serialize;
 use std::fmt;
 
+#[macro_export]
+/// emit a compiler error
+macro_rules! error {
+    ($($msg:tt)*) => {{
+        let msg = format!($($msg)*);
+        PluginError::new(-1, &msg, None)
+    }};
+}
+
 #[derive(Debug, Clone, Serialize)]
 /// Type defining JSONRPCv2.0 compliant plugin errors defined here
 /// https://www.jsonrpc.org/specification#error_object
@@ -29,5 +38,15 @@ impl PluginError {
 impl fmt::Display for PluginError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "code: {}, msg: {}", self.code, self.msg)
+    }
+}
+
+impl From<serde_json::Error> for PluginError {
+    fn from(e: serde_json::Error) -> Self {
+        PluginError {
+            code: -1,
+            msg: format!("{e}"),
+            data: None,
+        }
     }
 }

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -81,8 +81,8 @@ impl<'a, T: 'a + Clone> Plugin<T> {
         add_str(&mut payload, "message", msg);
         let request = Request {
             id: None,
-            jsonrpc: "2.0",
-            method: "log",
+            jsonrpc: "2.0".to_owned(),
+            method: "log".to_owned(),
             params: payload,
         };
         writer
@@ -148,13 +148,13 @@ impl<'a, T: 'a + Clone> Plugin<T> {
     fn call_rpc_method(
         &'a mut self,
         name: &str,
-        params: &serde_json::Value,
+        params: serde_json::Value,
     ) -> Result<serde_json::Value, PluginError> {
         let command = self.rpc_method.get(name).unwrap().clone();
         command.call(self, params)
     }
 
-    fn handle_notification(&'a mut self, name: &str, params: &serde_json::Value) {
+    fn handle_notification(&'a mut self, name: &str, params: serde_json::Value) {
         let notification = self.rpc_notification.get(name).unwrap().clone();
         if let Err(json_res) = notification.call(self, params) {
             self.log(
@@ -233,7 +233,7 @@ impl<'a, T: 'a + Clone> Plugin<T> {
             let request: Request<serde_json::Value> = serde_json::from_str(&req_str).unwrap();
             if let Some(id) = request.id {
                 // when the id is specified this is a RPC or Hook, so we need to return a response
-                let response = self.call_rpc_method(request.method, &request.params);
+                let response = self.call_rpc_method(&request.method, request.params);
                 let mut rpc_response = init_success_response(id);
                 self.write_respose(&response, &mut rpc_response);
                 writer
@@ -243,7 +243,7 @@ impl<'a, T: 'a + Clone> Plugin<T> {
             } else {
                 // in case of the id is None, we are receiving the notification, so the server is not
                 // interested in the answer.
-                self.handle_notification(request.method, &request.params);
+                self.handle_notification(&request.method, request.params);
             }
         }
     }

--- a/plugin/tests/plugin_integration_test.rs
+++ b/plugin/tests/plugin_integration_test.rs
@@ -18,5 +18,8 @@ fn plugin_rpc_call_call(lightningd: Client) {
     let response = lightningd
         .send_request::<HashMap<String, Value>, HashMap<String, Value>>("hello", HashMap::new())
         .unwrap();
+    println!("{:#?}", response);
+    assert!(response.result.is_some());
+    assert!(response.error.is_none());
     assert!(response.result.unwrap().contains_key("language"));
 }

--- a/plugin_macros/Cargo.toml
+++ b/plugin_macros/Cargo.toml
@@ -19,8 +19,8 @@ quote = "1.0"
 darling = "0.14.1"
 convert_case = "0.5.0"
 serde_json = "1.0"
-#clightningrpc-plugin = { path = "../plugin"}
-clightningrpc-plugin = "0.3.0-beta.3"
+clightningrpc-plugin = { path = "../plugin"}
+#clightningrpc-plugin = "0.3.0-beta.3"
 
 [dev-dependencies]
 rstest = "0.10.0"

--- a/plugin_macros/src/lib.rs
+++ b/plugin_macros/src/lib.rs
@@ -141,7 +141,7 @@ fn generate_rpc_method(item: &TokenStream, method_call: &RPCCall) -> String {
 
 
     impl<T: Clone + 'static> RPCCommand<T> for {}<T> {{
-       fn call<'c>(&self, _plugin: &mut Plugin<T>, _request: &'c Value) -> Result<Value, PluginError> {{
+       fn call<'c>(&self, _plugin: &mut Plugin<T>, _request: Value) -> Result<Value, PluginError> {{
            {}
        }}
     }}

--- a/plugin_macros/tests/plugin_integration_test.rs
+++ b/plugin_macros/tests/plugin_integration_test.rs
@@ -18,5 +18,6 @@ fn plugin_macros_rpc_call_call(lightningd: Client) {
     let response = lightningd
         .send_request::<HashMap<String, Value>, HashMap<String, Value>>("foo_macro", HashMap::new())
         .unwrap();
+    println!("{:#?}", response);
     assert!(response.result.unwrap().contains_key("is_dynamic"));
 }

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -8,4 +8,4 @@ cd .. || exit 1
 sleep 0.5m # Give the time to c-lightning to sync the network
 cd code || exit 1
 echo "Running test with Cargo"
-cargo test --workspace
+RUST_BACKTRACE=full cargo test --workspace -- --nocapture


### PR DESCRIPTION
Core lightning change the id typ from int to string, to allow a better identification of quest from plugin.

So this commit support this new kind of id and remove the str type inside the request in favor of String.

The main motivation to switch from str to String is to remove the lifetime that did not work so well with serde.