### PR TITLE
feat(test): Implementing a new test framework for core lightning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
         "plugin",
         "plugin_macros",
         "conf",
+        "testing",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ These are the complete list of craters supported right now
 | clightningrpc-plugin |    Crate that provides a plugin API to give the possibility to implement a plugin in Rust     | ![Crates.io](https://img.shields.io/crates/v/clightningrpc-plugin?style=flat-square) |
 | clightningrpc-plugin-macros |    Crate that provides a procedural macros implementation to make easy to develop a plugin developer to build a plugin     | ![Crates.io](https://img.shields.io/crates/v/clightningrpc-plugin_macros?style=flat-square) |
 | clightningrpc-conf |    This crate provides configuration manager for core lightning.    | ![Crates.io](https://img.shields.io/crates/v/clightningrpc-conf?style=flat-square) |
+| clightningrpc-testing |    This crate provides test framework for core lightning (including bitcoin).    | unrelated |
 
 ## Contributing guidelines
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Read our [Hacking guide](/docs/MAINTAINERS.md)
 
 If you want to support this library, consider donating with the following methods
 
-- Lightning address: vincenzopalazzo@lntxbot.com
+- Lightning address: vincenzopalazzo@coinos.io
+- BOLT 12: https://bruce.lnmetrics.info/donation
 - [Github donation](https://github.com/sponsors/vincenzopalazzo)
 
 ## Credits

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -90,5 +90,6 @@ Read our [Hacking guide](https://github.com/laanwj/rust-clightning-rpc/blob/mast
 
 If you want support this library consider to donate with the following methods
 
-- Lightning address: vincenzopalazzo@lntxbot.com
+- Lightning address: vincenzopalazzo@coinos.io
+- BOLT 12: https://bruce.lnmetrics.info/donation
 - [Github donation](https://github.com/sponsors/vincenzopalazzo)

--- a/plugin_macros/README.md
+++ b/plugin_macros/README.md
@@ -90,5 +90,6 @@ fn main() {
 
 If you want support this library consider to donate with the following methods
 
-- Lightning address: vincenzopalazzo@lntxbot.com
+- Lightning address: vincenzopalazzo@coinos.io
+- BOLT 12: https://bruce.lnmetrics.info/donation
 - [Github donation](https://github.com/sponsors/vincenzopalazzo)

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -93,7 +93,8 @@ N.B: A good solution if you have some missing compatibility between core lightni
 
 If you want support this library consider to donate with the following methods
 
-- Lightning address: vincenzopalazzo@lntxbot.com
+- Lightning address: vincenzopalazzo@coinos.io
+- BOLT 12: https://bruce.lnmetrics.info/donation
 - [Github donation](https://github.com/sponsors/vincenzopalazzo)
 
 # Credits

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "clightning-testing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clightningrpc = { path = "../rpc"  }
+bitcoincore-rpc = "0.17.0"
+log = "^0.4"
+tempfile = "3.6.0"
+port-selector = "0.1.6"
+anyhow = "1.0.71"
+tokio = { version = "1.22.0", features = ["process", "time", "fs"] }

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,39 @@
+<div align="center">
+  <h1>Core Lightning rust test framework</h1>
+
+  <p>
+    <strong>Crate that provides a test framework for core lightning.</strong>
+  </p>
+
+  <p>
+  </p>
+
+  <h4>
+    <a href="https://github.com/laanwj/rust-clightning-rpc">Project Homepage</a>
+  </h4>
+ 
+  <a href="https://docs.rs/clightning-testing">
+    <img alt="docs.rs" src="https://img.shields.io/docsrs/clightning-testing?style=flat-square"/>
+  </a>
+
+</div>
+
+Crate that provides a testing framework for core lightning (including bitcoin).
+
+```rust
+// TODO
+```
+
+# Contributing guidelines
+
+- Four spaces
+- Call `make fmt` before committing
+- If you can, GPG-sign at least your top commit when filing a PR
+
+# Supports
+
+If you want support this library consider to donate with the following methods
+
+- Lightning address: vincenzopalazzo@coinos.io
+- BOLT 12: https://bruce.lnmetrics.info/donation
+- [Github donation](https://github.com/sponsors/vincenzopalazzo)

--- a/testing/src/btc.rs
+++ b/testing/src/btc.rs
@@ -1,0 +1,112 @@
+//! Bitcoin Testing framework.
+//!
+use std::cell::RefCell;
+
+use bitcoincore_rpc::{Auth, Client, RpcApi};
+use port::Port;
+use port_selector as port;
+use tempfile::TempDir;
+
+pub mod macros {
+    #[macro_export]
+    macro_rules! bitcoind {
+        ($dir:expr, $port:expr, $opt_args:expr) => {
+            async {
+                use std::process::Stdio;
+
+                use log;
+                use tokio::process::Command;
+
+                let opt_args = format!($opt_args);
+                let args = opt_args.trim();
+                let args_tok: Vec<&str> = args.split(" ").collect();
+                log::debug!("additional args: {:?}", args_tok);
+                let mut command = Command::new("bitcoind");
+                command
+                    .args(&args_tok)
+                    .arg(format!("-port={}", $port + 1))
+                    .arg(format!("-rpcport={}", $port))
+                    .arg(format!("-datadir={}", $dir.path().to_str().unwrap()))
+                    .stdout(Stdio::null())
+                    .spawn()
+            }
+            .await
+        };
+        ($dir:expr, $port:expr) => {
+            $crate::bitcoind!($dir, $port, "")
+        };
+    }
+
+    pub use bitcoind;
+}
+
+pub struct BtcNode {
+    inner: Client,
+    pub user: String,
+    pub pass: String,
+    pub port: Port,
+    root_path: TempDir,
+    process: RefCell<Vec<tokio::process::Child>>,
+}
+
+impl Drop for BtcNode {
+    fn drop(&mut self) {
+        for process in self.process.borrow().iter() {
+            let Some(child) = process.id() else {
+                continue;
+            };
+            let Ok(mut kill) = std::process::Command::new("kill")
+                .args(["-s", "SIGKILL", &child.to_string()])
+                .spawn()
+            else {
+                continue;
+            };
+            let _ = kill.wait();
+        }
+
+        let result = std::fs::remove_dir_all(self.root_path.path());
+        log::debug!(target: "btc", "clean up function {:?}", result);
+    }
+}
+
+impl BtcNode {
+    pub async fn tmp(network: &str) -> anyhow::Result<Self> {
+        let dir = tempfile::tempdir()?;
+        let user = "crab".to_owned();
+        let pass = "crab".to_owned();
+        let port = port::random_free_port().unwrap();
+        let process = macros::bitcoind!(
+            dir,
+            port,
+            "-server -{network} -rpcuser={user} -rpcpassword={pass}"
+        )?;
+        let rpc = Client::new(
+            &format!("http://localhost:{port}"),
+            Auth::UserPass(user.clone(), pass.clone()),
+        )?;
+        let bg_process = vec![process];
+        Ok(Self {
+            inner: rpc,
+            root_path: dir,
+            user,
+            pass,
+            port,
+            process: bg_process.into(),
+        })
+    }
+
+    pub fn rpc(&self) -> &Client {
+        &self.inner
+    }
+
+    pub async fn stop(&self) -> anyhow::Result<()> {
+        log::info!("stop bitcoin node");
+        self.inner.stop()?;
+        for process in self.process.borrow_mut().iter_mut() {
+            process.kill().await?;
+            let _ = process.wait().await?;
+            log::debug!("process killed");
+        }
+        Ok(())
+    }
+}

--- a/testing/src/cln.rs
+++ b/testing/src/cln.rs
@@ -1,0 +1,134 @@
+//! Integration testing library for core lightning
+use std::sync::Arc;
+
+use port_selector as port;
+use tempfile::TempDir;
+
+use clightningrpc::LightningRPC;
+
+use crate::btc::BtcNode;
+use crate::prelude::*;
+
+pub mod macros {
+    #[macro_export]
+    macro_rules! lightningd {
+        ($dir:expr, $port:expr, $($opt_args:tt)*) => {
+            async {
+                use std::process::Stdio;
+
+                use tokio::process::Command;
+
+                let opt_args = format!($($opt_args)*);
+                let args = opt_args.trim();
+                let args_tok: Vec<&str> = args.split(" ").collect();
+
+                let path = format!("{}/.lightning", $dir.path().to_str().unwrap());
+                log::info!("core lightning home {path}");
+                check_dir_or_make_if_missing(path.clone()).await.unwrap();
+                let mut command = Command::new("lightningd");
+                command
+                    .args(&args_tok)
+                    .arg(format!("--addr=127.0.0.1:{}", $port))
+                    .arg(format!("--bind-addr=127.0.0.1:{}", $port + 1))
+                    .arg(format!("--lightning-dir={path}"))
+                    .arg("--dev-fast-gossip")
+                    .arg("--funding-confirms=1")
+                    .stdout(Stdio::null())
+                    .spawn()
+            }.await
+        };
+        ($dir:expr, $port:expr) => {
+            $crate::lightningd!($dir, $port, "")
+        };
+    }
+
+    pub use lightningd;
+}
+
+pub struct Node {
+    inner: Arc<LightningRPC>,
+    pub port: u16,
+    root_path: Arc<TempDir>,
+    bitcoin: Arc<BtcNode>,
+    process: Vec<tokio::process::Child>,
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        for process in self.process.iter() {
+            let Some(child) = process.id() else {
+                continue;
+            };
+            let Ok(mut kill) = std::process::Command::new("kill")
+                .args(["-s", "SIGKILL", &child.to_string()])
+                .spawn()
+            else {
+                continue;
+            };
+            let _ = kill.wait();
+        }
+
+        let result = std::fs::remove_dir_all(self.root_path.path());
+        log::debug!(target: "cln", "clean up function {:?}", result);
+    }
+}
+
+impl Node {
+    pub async fn tmp(network: &str) -> anyhow::Result<Self> {
+        Self::with_params("", network).await
+    }
+
+    pub async fn with_params(params: &str, network: &str) -> anyhow::Result<Self> {
+        let btc = BtcNode::tmp(network).await?;
+        let btc = Arc::new(btc);
+
+        let dir = tempfile::tempdir()?;
+        let port = port::random_free_port().unwrap();
+        let process = macros::lightningd!(
+            dir,
+            port,
+            "--network={} --log-level=debug --bitcoin-rpcuser={} --bitcoin-rpcpassword={} --bitcoin-rpcport={} {}",
+            network,
+            btc.user,
+            btc.pass,
+            btc.port,
+            params,
+        )?;
+
+        let rpc = LightningRPC::new(
+            dir.path()
+                .join(format!(".lightning/{}", network))
+                .join("lightning-rpc"),
+        );
+        let rpc = Arc::new(rpc);
+        wait_for!(async { rpc.getinfo() });
+
+        Ok(Self {
+            inner: rpc,
+            root_path: dir.into(),
+            bitcoin: btc,
+            port,
+            process: vec![process],
+        })
+    }
+
+    pub fn rpc(&self) -> Arc<LightningRPC> {
+        self.inner.clone()
+    }
+
+    pub fn btc(&self) -> Arc<BtcNode> {
+        self.bitcoin.clone()
+    }
+
+    pub async fn stop(&mut self) -> anyhow::Result<()> {
+        log::info!("stop lightning node");
+        self.inner.stop()?;
+        for process in self.process.iter_mut() {
+            process.kill().await?;
+            let _ = process.wait().await?;
+            log::debug!("killing process");
+        }
+        self.bitcoin.stop().await?;
+        Ok(())
+    }
+}

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -1,0 +1,52 @@
+pub mod btc;
+pub mod cln;
+
+pub mod prelude {
+    pub use port_selector as port;
+    pub use tempfile;
+
+    pub use bitcoincore_rpc;
+    pub use clightningrpc;
+
+    pub use crate::check_dir_or_make_if_missing;
+    pub use crate::macros::*;
+}
+
+pub mod macros {
+    #[macro_export]
+    macro_rules! wait_for {
+        ($callback:expr, $timeout:expr) => {
+            use log;
+            use tokio::time::{sleep, Duration};
+
+            for wait in 0..$timeout {
+                if let Err(_) = $callback.await {
+                    sleep(Duration::from_millis(wait)).await;
+                    continue;
+                }
+                log::info!("callback completed in {wait} milliseconds");
+                break;
+            }
+        };
+        ($callback:expr) => {
+            use crate::DEFAULT_TIMEOUT;
+
+            $crate::wait_for!($callback, DEFAULT_TIMEOUT);
+        };
+    }
+
+    pub use wait_for;
+}
+
+static DEFAULT_TIMEOUT: u64 = 100;
+
+pub async fn check_dir_or_make_if_missing(path: String) -> anyhow::Result<()> {
+    use std::path::Path;
+    use tokio::fs::create_dir;
+
+    if !Path::exists(Path::new(&path.to_owned())) {
+        create_dir(path.clone()).await?;
+        log::debug!("created dir {path}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
This commit implements a minimal and configurable core lightning test framework that allows spinning up a core lightning node and a Bitcoin node, and controlling them through the RPC API.