### PR TITLE
fix(rpc): re-export lightningrpc::Error

### DIFF
--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.0-beta.7
+
+## Fixed
+- re-export lightningrpc::Error ([commit](https://github.com/laanwj/cln4rust/commit/951bb8772a9ba1563bddb0752d22fa3dbd9ea45b)). @vincenzopalazzo 24-08-2023
+
+
 # v0.3.0-beta.5
 
 ## Fixed

--- a/rpc/changelog.json
+++ b/rpc/changelog.json
@@ -1,10 +1,10 @@
 {
   "package_name": "rpc",
-  "version": "v0.3.0-beta.6",
+  "version": "v0.3.0-beta.7",
   "api": {
     "name": "github",
     "repository": "laanwj/rust-clightning-rpc",
-    "branch": "master"
+    "branch": "macros/expose-errors"
   },
   "generation_method": {
     "name": "semver-v2",

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -38,3 +38,4 @@ pub mod types;
 
 // Re-export high-level connection type
 pub use crate::lightningrpc::LightningRPC;
+pub use clightningrpc_common::errors::Error;


### PR DESCRIPTION
In `v0.2.0` the `pub enum Error` are defined in `error.rs` file included in the `clightningrpc`, and I can import in my example by `clightningrpc::Error`.

In the following releases, the `error.rs` file is moved inside `common` subfolder, but it looks no public exposed from `clightningrpc`. A fast fix could be mark as public the following line `pub use clightningrpc_common::errors::Error;` in `lightningrpc`. So I could import the `enum Error` in my example by `clightningrpc::lightningrpc::Error`.

Suggested-by: @lvaccaro <me@lvaccaro.com>