### PR TITLE
fix(plugin): do not panic while looks for new options

### DIFF
--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -1,18 +1,21 @@
 //! Core of the plugin API
 //!
 //! Unofficial API interface to develop plugin in Rust.
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::io::Write;
+use std::string::String;
+use std::sync::Arc;
+
+use clightningrpc_common::json_utils::{add_str, init_payload, init_success_response};
+use clightningrpc_common::types::Request;
+use serde_json::Value;
+
 use crate::commands::builtin::{InitRPC, ManifestRPC};
 use crate::commands::types::{CLNConf, RPCHookInfo, RPCMethodInfo};
 use crate::commands::RPCCommand;
 use crate::errors::PluginError;
 use crate::types::{LogLevel, RpcOption};
-use clightningrpc_common::json_utils::{add_str, init_payload, init_success_response};
-use clightningrpc_common::types::Request;
-use serde_json::Value;
-use std::collections::{HashMap, HashSet};
-use std::string::String;
-use std::sync::Arc;
-use std::{io, io::Write};
 
 #[cfg(feature = "log")]
 pub use log::*;
@@ -149,12 +152,8 @@ impl<'a, T: 'a + Clone> Plugin<T> {
     }
 
     /// get an optionue that cln sent back to the plugin.
-    pub fn get_opt<R: for<'de> serde::de::Deserialize<'de>>(
-        &self,
-        name: &str,
-    ) -> Result<R, PluginError> {
-        let opt = self.option.get(name).unwrap();
-        Ok(opt.value())
+    pub fn get_opt<R: for<'de> serde::de::Deserialize<'de>>(&self, name: &str) -> Option<R> {
+        self.option.get(name).and_then(|value| value.value())
     }
 
     // FIXME: adding the long description as parameter


### PR DESCRIPTION
```
thread 'main' panicked at /home/vincent/.cargo/git/checkouts/cln4rust-0de0305144cd79e4/5412f22/plugin/src/types.rs:28:69: called `Option::unwrap()` on a `None` value
stack backtrace:
   0: rust_begin_unwind
             at /rustc/13e6f24b9adda67852fb86538541adaa68aff6e8/library/std/src/panicking.rs:597:5
   1: core::panicking::panic_fmt
             at /rustc/13e6f24b9adda67852fb86538541adaa68aff6e8/library/core/src/panicking.rs:72:14
   2: core::panicking::panic
             at /rustc/13e6f24b9adda67852fb86538541adaa68aff6e8/library/core/src/panicking.rs:127:5
   3: clightningrpc_plugin::types::RpcOption::value
   4: clightningrpc_plugin::plugin::Plugin<T>::get_opt
   5: folgore_plugin::plugin::on_init
   6: core::ops::function::Fn::call
   7: <clightningrpc_plugin::commands::builtin::InitRPC<T> as clightningrpc_plugin::commands::RPCCommand<T>>::call
   8: clightningrpc_plugin::plugin::Plugin<T>::start
   9: folgore_plugin::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2023-09-28T18:50:00.651Z INFO    plugin-folgore_plugin: Killing plugin: exited before we sent init
The Bitcoin backend died.
```

Fixes: https://github.com/laanwj/cln4rust/issues/113