### PR TITLE
plugin: allow to exectute in an async way

### DIFF
--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clightningrpc-common = { version = "0.3.0-beta.4" }
 log = { version = "0.4.17", optional = true }
+tokio = { version = "1.37.0", features = ["rt-multi-thread", "io-util", "io-std", "sync"]  }
 
 [features]
 log = ["dep:log"]

--- a/plugin/examples/foo_plugin.rs
+++ b/plugin/examples/foo_plugin.rs
@@ -35,7 +35,8 @@ impl RPCCommand<PluginState> for OnShutdown {
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let plugin = Plugin::<PluginState>::new(PluginState(()), true)
         .add_rpc_method(
             "hello",
@@ -56,5 +57,5 @@ fn main() {
             json!({})
         })
         .clone();
-    plugin.start();
+    plugin.start().await;
 }


### PR DESCRIPTION
This is the first step to allow async execution inside rpc method, to call an rpc method while running another rpc method.

Currently this is a retro compatible change but we do not support async rpc definition