### PR TITLE
rpc: fix the stop response

### DIFF
--- a/rpc/src/responses.rs
+++ b/rpc/src/responses.rs
@@ -531,4 +531,7 @@ pub struct NewAddr {
 }
 
 /// 'stop' command
-pub type Stop = String;
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Stop {
+    pub result: Option<String>,
+}


### PR DESCRIPTION
Find on lampo ci 

stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: core::result::Result<T,E>::unwrap
             at /build/rustc-1.75.0-src/library/core/src/result.rs:1077:23
   4: tests::lampo_cln_tests::test_lampo_to_cln_close_channel_with_channel_id_success
             at ./src/lampo_cln_tests.rs:985:5
   5: tests::lampo_cln_tests::test_lampo_to_cln_close_channel_with_channel_id_success::{{closure}}
             at ./src/lampo_cln_tests.rs:887:61
   6: core::ops::function::FnOnce::call_once
             at /build/rustc-1.75.0-src/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

---- lampo_cln_tests::test_lampo_to_cln_close_channel_without_channel_id_success stdout ----
thread 'lampo_cln_tests::test_lampo_to_cln_close_channel_without_channel_id_success' panicked at tests/tests/src/lampo_cln_tests.rs:1087:28:
called `Result::unwrap()` on an `Err` value: JSON decode error: invalid type: map, expected a string at line 1 column 36

https://github.com/vincenzopalazzo/lampo.rs/pull/249