### PR TITLE
 Update 'close' method and add 'offer' commands

### DIFF
--- a/rpc/src/lightningrpc.rs
+++ b/rpc/src/lightningrpc.rs
@@ -531,6 +531,83 @@ impl LightningRPC {
         )
     }
 
+    /// Create a new offer.
+    #[deprecated(
+        since = "0.1.0",
+        note = "Core Lightning API changes frequently, making strongly typed methods hard to maintain. Use the generic `call` method with serde_json until a compiler is shipped or the API stabilizes."
+    )]
+    #[allow(clippy::too_many_arguments)]
+    pub fn offer<'a>(
+        &self,
+        amount: &'a str,
+        description: &'a str,
+        issuer: Option<&'a str>,
+        label: Option<&'a str>,
+        quantity_min: Option<u64>,
+        quantity_max: Option<u64>,
+        absolute_expiry: Option<u64>,
+        recurrence: Option<&'a str>,
+        recurrence_base: Option<&'a str>,
+        recurrence_paywindow: Option<&'a str>,
+        recurrence_limit: Option<u32>,
+        single_use: Option<bool>,
+    ) -> Result<responses::OfferResponse, Error> {
+        self.call(
+            "offer",
+            requests::Offer {
+                amount,
+                description,
+                issuer,
+                label,
+                quantity_min,
+                quantity_max,
+                absolute_expiry,
+                recurrence,
+                recurrence_base,
+                recurrence_paywindow,
+                recurrence_limit,
+                single_use,
+            },
+        )
+    }
+
+    /// List all offers.
+    #[deprecated(
+        since = "0.1.0",
+        note = "Core Lightning API changes frequently, making strongly typed methods hard to maintain. Use the generic `call` method with serde_json until a compiler is shipped or the API stabilizes."
+    )]
+    pub fn listoffers(
+        &self,
+        offer_id: Option<&str>,
+        active_only: Option<bool>,
+    ) -> Result<responses::ListOffersResponse, Error> {
+        self.call(
+            "listoffers",
+            requests::ListOffers {
+                offer_id,
+                active_only,
+            },
+        )
+    }
+
+    /// Enable an offer.
+    #[deprecated(
+        since = "0.1.0",
+        note = "Core Lightning API changes frequently, making strongly typed methods hard to maintain. Use the generic `call` method with serde_json until a compiler is shipped or the API stabilizes."
+    )]
+    pub fn enableoffer(&self, offer_id: &str) -> Result<responses::EnableOfferResponse, Error> {
+        self.call("enableoffer", requests::EnableOffer { offer_id })
+    }
+
+    /// Disable an offer.
+    #[deprecated(
+        since = "0.1.0",
+        note = "Core Lightning API changes frequently, making strongly typed methods hard to maintain. Use the generic `call` method with serde_json until a compiler is shipped or the API stabilizes."
+    )]
+    pub fn disableoffer(&self, offer_id: &str) -> Result<responses::DisableOfferResponse, Error> {
+        self.call("disableoffer", requests::DisableOffer { offer_id })
+    }
+
     /// Send {peerid} a ping of length {len} (default 128) asking for {pongbytes} (default 128).
     #[deprecated(
         since = "0.1.0",

--- a/rpc/src/lightningrpc.rs
+++ b/rpc/src/lightningrpc.rs
@@ -497,20 +497,38 @@ impl LightningRPC {
         )
     }
 
-    /// Close the channel with {id} (either peer ID, channel ID, or short channel ID). If {force}
-    /// (default false) is true, force a unilateral close after {timeout} seconds (default 30),
-    /// otherwise just schedule a mutual close later and fail after timing out.
+    /// Close the channel with {id} (either peer ID, channel ID, or short channel ID).
+    /// To force a unilateral close, set {unilateraltimeout} to the desired number of seconds.
+    /// Note: A force close is not possible with an active peer connection; the peer must be disconnected.
+    /// If the peer is offline, the channel will be closed unilaterally after the timeout.
+    /// A short timeout (e.g., 1 second) is recommended for a force close if the peer is unresponsive.
     #[deprecated(
         since = "0.1.0",
         note = "Core Lightning API changes frequently, making strongly typed methods hard to maintain. Use the generic `call` method with serde_json until a compiler is shipped or the API stabilizes."
     )]
-    pub fn close(
+    #[allow(clippy::too_many_arguments)]
+    pub fn close<'a>(
         &self,
-        id: &str,
-        force: Option<bool>,
-        timeout: Option<u64>,
+        id: &'a str,
+        unilateraltimeout: Option<u32>,
+        destination: Option<&'a str>,
+        fee_negotiation_step: Option<&'a str>,
+        wrong_funding: Option<&'a str>,
+        force_lease_closed: Option<bool>,
+        feerange: Option<Vec<&'a str>>,
     ) -> Result<responses::Close, Error> {
-        self.call("close", requests::Close { id, force, timeout })
+        self.call(
+            "close",
+            requests::Close {
+                id,
+                unilateraltimeout,
+                destination,
+                fee_negotiation_step,
+                wrong_funding,
+                force_lease_closed,
+                feerange,
+            },
+        )
     }
 
     /// Send {peerid} a ping of length {len} (default 128) asking for {pongbytes} (default 128).

--- a/rpc/src/requests.rs
+++ b/rpc/src/requests.rs
@@ -279,9 +279,17 @@ pub struct FundChannel<'a> {
 pub struct Close<'a> {
     pub id: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub force: Option<bool>,
+    pub unilateraltimeout: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub timeout: Option<u64>,
+    pub destination: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fee_negotiation_step: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wrong_funding: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_lease_closed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feerange: Option<Vec<&'a str>>,
 }
 
 /// 'ping' command

--- a/rpc/src/requests.rs
+++ b/rpc/src/requests.rs
@@ -327,3 +327,51 @@ pub struct NewAddr<'a> {
 /// 'stop' command
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Stop {}
+
+/// 'offer' command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Offer<'a> {
+    pub amount: &'a str,
+    pub description: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quantity_min: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quantity_max: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub absolute_expiry: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurrence: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurrence_base: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurrence_paywindow: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurrence_limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub single_use: Option<bool>,
+}
+
+/// 'listoffers' command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ListOffers<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offer_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_only: Option<bool>,
+}
+
+/// 'enableoffer' command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EnableOffer<'a> {
+    pub offer_id: &'a str,
+}
+
+/// 'disableoffer' command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DisableOffer<'a> {
+    pub offer_id: &'a str,
+}

--- a/rpc/src/responses.rs
+++ b/rpc/src/responses.rs
@@ -535,3 +535,27 @@ pub struct NewAddr {
 pub struct Stop {
     pub result: Option<String>,
 }
+
+/// 'offer' command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OfferResponse {
+    pub offer_id: String,
+    pub active: bool,
+    pub single_use: bool,
+    pub bolt12: String,
+    pub used: bool,
+    pub created: bool,
+    pub label: Option<String>,
+}
+
+/// 'listoffers' command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ListOffersResponse {
+    pub offers: Vec<OfferResponse>,
+}
+
+/// 'enableoffer' command
+pub type EnableOfferResponse = OfferResponse;
+
+/// 'disableoffer' command
+pub type DisableOfferResponse = OfferResponse;


### PR DESCRIPTION
Aligns the RPC client with the latest Core Lightning API documentation and introduces support for [offer](https://docs.corelightning.org/reference/offer)-related commands.
### Updated [close](https://docs.corelightning.org/reference/close) Method
The [close](https://docs.corelightning.org/reference/close) request struct and the high-level LightningRPC::close method have been updated to use the modern parameters specified in the official documentation. Deprecated fields like force and timeout were replaced with unilateraltimeout, destination, feerange, and others to provide more granular control. Additionally, the documentation comment for the close method was improved to clarify how to perform a unilateral (force) close, including the important note that the peer must be disconnected for this operation.
### Added offer Commands
Support for the BOLT12 offer command set has been added, allowing for the creation and management of offers directly from the client. The following new high-level methods are now available on **LightningRPC**:
- [offer](https://docs.corelightning.org/reference/offer)
- [list_offers](https://docs.corelightning.org/reference/listoffers)
- [enable_offer](https://docs.corelightning.org/reference/enableoffer)
- [disable_offer](https://docs.corelightning.org/reference/disableoffer)